### PR TITLE
Bump version, and add description in cargo.toml; update readme

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustformers"
-description = "a transformers like interface for interacting with local LLMs"
+description = "A transformers like interface for interacting with local LLMs"
 version = "0.0.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustformers"
-description = "Rust transformers"
-version = "0.0.0"
+description = "a transformers like interface for interacting with local LLMs"
+version = "0.0.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/ljt019/rustformers/"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # rustformers
 
-My goal with this crate is to make a really basic and simple interface to use popular local LLMs. Candle makes working with LLMs in Rust do-able but it's quite tedious to use, I hope to make an API that falls more in line with python's transformers but in a Rust fashion.
+My goal with this crate is to make a really basic and simple interface to use popular local LLMs. [Candle](https://github.com/huggingface/candle) is a Rust-based framework for machine learning, making it possible to work with LLMs in Rust, though it can be tedious to use. I hope to create an API that aligns more closely with [python's transformers](https://huggingface.co/docs/transformers), a popular Python library for working with transformer models, but in a Rust fashion.
 
 I probably will start with implementing a basic text-pipeline with Qwen3, candle so far only supports the non-moe models so I will likely start with those.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # rustformers
+
+My goal with this crate is to make a really basic and simple interface to use popular local LLMs. Candle makes working with LLMs in Rust do-able but it's quite tedious to use, I hope to make an API that falls more in line with python's transformers but in a Rust fashion.
+
+I probably will start with implementing a basic text-pipeline with Qwen3, candle so far only supports the non-moe models so I will likely start with those.


### PR DESCRIPTION
This pull request introduces updates to the `rustformers` crate, including changes to the project metadata and the addition of a project description in the `README.md`. These changes aim to clarify the purpose of the crate and provide a more descriptive interface for potential users.

### Metadata updates:
* Updated the `description` and `version` fields in `Cargo.toml` to better reflect the purpose of the crate and its current development stage. (`[Cargo.tomlL3-R4](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L3-R4)`)

### Documentation improvements:
* Added a project overview to `README.md`, explaining the goal of creating a simple interface for local LLMs inspired by Python's transformers, with an initial focus on Qwen3 models. (`[README.mdR2-R5](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R2-R5)`)